### PR TITLE
Fix  contadores de pets

### DIFF
--- a/central-pet-back/src/modules/admin/admin.service.spec.ts
+++ b/central-pet-back/src/modules/admin/admin.service.spec.ts
@@ -4,6 +4,7 @@ import { AdminService } from './admin.service';
 import { PrismaService } from '@/prisma/prisma.service';
 import { UsersService } from '@/modules/users/users.service';
 import { PetsService } from '@/modules/pets/pets.service';
+import { PetStatsEventsService } from '@/modules/pets/pet-stats-events.service';
 import { AuditService } from '@/modules/audit/audit.service';
 import { prismaMock } from '../../../singleton';
 import { Pet } from '../../../generated/prisma/client';
@@ -12,6 +13,7 @@ describe('AdminService', () => {
   let service: AdminService;
   let usersServiceMock: UsersService;
   let petsServiceMock: PetsService;
+  let petStatsEventsMock: PetStatsEventsService;
   let auditServiceMock: AuditService;
 
   beforeEach(() => {
@@ -32,6 +34,10 @@ describe('AdminService', () => {
       reactivatePetTransactional: jest.fn(),
     } as unknown as PetsService;
 
+    petStatsEventsMock = {
+      emitChanged: jest.fn(),
+    } as unknown as PetStatsEventsService;
+
     auditServiceMock = {
       create: jest.fn(),
       createWithTx: jest.fn(),
@@ -41,6 +47,7 @@ describe('AdminService', () => {
       prismaMock as unknown as PrismaService,
       usersServiceMock as unknown as UsersService,
       petsServiceMock as unknown as PetsService,
+      petStatsEventsMock,
       auditServiceMock as unknown as AuditService,
     );
   });

--- a/central-pet-back/src/modules/admin/admin.service.ts
+++ b/central-pet-back/src/modules/admin/admin.service.ts
@@ -12,6 +12,7 @@ import { UsersService } from '@/modules/users/users.service';
 import { AdminCreateUserDto } from '@/modules/users/dto/admin-create-user.dto';
 import { AuditService } from '@/modules/audit/audit.service';
 import { PetsService } from '@/modules/pets/pets.service';
+import { PetStatsEventsService } from '@/modules/pets/pet-stats-events.service';
 import { generateRandomPassword } from '@/modules/auth/password.util';
 import { ModerationTargetType } from '@/modules/moderation/moderation-target-type';
 
@@ -21,6 +22,7 @@ export class AdminService {
     private readonly prisma: PrismaService,
     private readonly usersService: UsersService,
     private readonly petsService: PetsService,
+    private readonly petStatsEvents: PetStatsEventsService,
     @Optional() private readonly auditService?: AuditService,
   ) {}
 
@@ -108,6 +110,8 @@ export class AdminService {
       }
     });
 
+    this.petStatsEvents.emitChanged();
+
     return { message: `Usuário ${shouldDeactivate ? 'desativado' : 'reativado'} com sucesso` };
   }
 
@@ -134,6 +138,8 @@ export class AdminService {
         });
       }
     });
+
+    this.petStatsEvents.emitChanged();
 
     return { message: `Pet ${shouldDelete ? 'bloqueado' : 'desbloqueado'} com sucesso` };
   }
@@ -250,6 +256,14 @@ export class AdminService {
         }
       }
     });
+
+    if (
+      status === ModerationStatus.APPROVED &&
+      blockPet &&
+      report.targetType === ModerationTargetType.PET
+    ) {
+      this.petStatsEvents.emitChanged();
+    }
 
     return { message: 'Denúncia resolvida com sucesso' };
   }

--- a/central-pet-back/src/modules/adoption-requests/adoption-requests.service.spec.ts
+++ b/central-pet-back/src/modules/adoption-requests/adoption-requests.service.spec.ts
@@ -409,7 +409,10 @@ describe('Servico de solicitacoes de adocao', () => {
       petsServiceMock,
     );
 
-    const shareContactUseCaseMock = new ShareContactUseCase(prismaMock as unknown as PrismaService);
+    const shareContactUseCaseMock = new ShareContactUseCase(
+      prismaMock as unknown as PrismaService,
+      petsServiceMock,
+    );
 
     const rejectAdoptionUseCaseMock = new RejectAdoptionUseCase(
       prismaMock as unknown as PrismaService,

--- a/central-pet-back/src/modules/adoption-requests/use-cases/approve-adoption.use-case.ts
+++ b/central-pet-back/src/modules/adoption-requests/use-cases/approve-adoption.use-case.ts
@@ -5,6 +5,7 @@ import type { ManageAdoptionRequestDto } from '../dto/manage-adoption-request.dt
 import type { AdoptionRequestRecord } from '@/modules/adoption-requests/models';
 import { AdoptionRequestStatus } from '@/modules/adoption-requests/models';
 import { AuditService } from '@/modules/audit/audit.service';
+import { PetStatsEventsService } from '@/modules/pets/pet-stats-events.service';
 
 @Injectable()
 export class ApproveAdoptionUseCase {
@@ -12,6 +13,7 @@ export class ApproveAdoptionUseCase {
     private readonly prisma: PrismaService,
     private readonly petsService: PetsService,
     @Optional() private readonly auditService?: AuditService,
+    @Optional() private readonly petStatsEvents?: PetStatsEventsService,
   ) {}
 
   async execute(
@@ -112,6 +114,8 @@ export class ApproveAdoptionUseCase {
 
       return { updatedReq, autoRejectedCount };
     });
+
+    this.petStatsEvents?.emitChanged();
 
     return {
       message:

--- a/central-pet-back/src/modules/pets/mappers/pet-record.mapper.spec.ts
+++ b/central-pet-back/src/modules/pets/mappers/pet-record.mapper.spec.ts
@@ -35,6 +35,9 @@ describe('PetMapper', () => {
     sourceName: 'Rafael Lima',
     status: PetStatus.AVAILABLE,
     deleted: false,
+    deletedAt: null,
+    deletedBy: null,
+    deletedReason: null,
     createdAt: new Date('2026-04-10T00:00:00Z'),
     updatedAt: new Date('2026-04-10T00:00:00Z'),
   };

--- a/central-pet-back/src/modules/pets/pet-stats-events.service.ts
+++ b/central-pet-back/src/modules/pets/pet-stats-events.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, type MessageEvent } from '@nestjs/common';
+import { Subject } from 'rxjs';
+
+export const PET_STATS_CHANGED_EVENT = 'pet-stats-changed';
+
+@Injectable()
+export class PetStatsEventsService {
+  private readonly changes = new Subject<MessageEvent>();
+
+  events() {
+    return this.changes.asObservable();
+  }
+
+  emitChanged() {
+    this.changes.next({
+      type: PET_STATS_CHANGED_EVENT,
+      data: { type: PET_STATS_CHANGED_EVENT },
+    });
+  }
+}

--- a/central-pet-back/src/modules/pets/pets.controller.spec.ts
+++ b/central-pet-back/src/modules/pets/pets.controller.spec.ts
@@ -7,6 +7,7 @@ import { UserPersistenceService } from '../users/user-persistence.service';
 import { PetsController } from './pets.controller';
 import { PetsService } from './pets.service';
 import { PetSeedService } from './pet-seed.service';
+import { PetStatsEventsService } from './pet-stats-events.service';
 
 describe('Controlador de pets', () => {
   let controller: PetsController;
@@ -44,6 +45,13 @@ describe('Controlador de pets', () => {
           provide: PetSeedService,
           useValue: {
             ensureSeed: () => Promise.resolve(),
+          },
+        },
+        {
+          provide: PetStatsEventsService,
+          useValue: {
+            events: () => undefined,
+            emitChanged: () => undefined,
           },
         },
       ],

--- a/central-pet-back/src/modules/pets/pets.controller.ts
+++ b/central-pet-back/src/modules/pets/pets.controller.ts
@@ -7,6 +7,7 @@ import {
   Patch,
   Post,
   Query,
+  Sse,
   UseGuards,
 } from '@nestjs/common';
 import { PetsService } from './pets.service';
@@ -16,10 +17,14 @@ import { UpdatePetDto } from './dto/update-pet.dto';
 import { SessionGuard } from '@/modules/auth/guards/session.guard';
 import { PetOwnerGuard } from './guards/pet-owner.guard';
 import { CurrentUser } from '@/decorators/current-user.decorator';
+import { PetStatsEventsService } from './pet-stats-events.service';
 
 @Controller('pets')
 export class PetsController {
-  constructor(private readonly petsService: PetsService) {}
+  constructor(
+    private readonly petsService: PetsService,
+    private readonly petStatsEvents: PetStatsEventsService,
+  ) {}
 
   @Post()
   @UseGuards(SessionGuard)
@@ -42,6 +47,11 @@ export class PetsController {
   @Get('stats')
   getStats() {
     return this.petsService.getStats();
+  }
+
+  @Sse('stats/events')
+  getStatsEvents() {
+    return this.petStatsEvents.events();
   }
 
   @Get(':id')

--- a/central-pet-back/src/modules/pets/pets.controller.ts
+++ b/central-pet-back/src/modules/pets/pets.controller.ts
@@ -39,6 +39,11 @@ export class PetsController {
     });
   }
 
+  @Get('stats')
+  getStats() {
+    return this.petsService.getStats();
+  }
+
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.petsService.findOne(id);

--- a/central-pet-back/src/modules/pets/pets.module.ts
+++ b/central-pet-back/src/modules/pets/pets.module.ts
@@ -7,11 +7,12 @@ import { PetsService } from './pets.service';
 import { UsersModule } from '@/modules/users/users.module';
 import { PetOwnerGuard } from './guards/pet-owner.guard';
 import { PetSeedService } from './pet-seed.service';
+import { PetStatsEventsService } from './pet-stats-events.service';
 
 @Module({
   imports: [PrismaModule, PersonalityTraitsModule, UsersModule],
   controllers: [PetsController],
-  providers: [PetsService, PetOwnerGuard, PetSeedService],
-  exports: [PetsService],
+  providers: [PetsService, PetOwnerGuard, PetSeedService, PetStatsEventsService],
+  exports: [PetsService, PetStatsEventsService],
 })
 export class PetsModule {}

--- a/central-pet-back/src/modules/pets/pets.service.spec.ts
+++ b/central-pet-back/src/modules/pets/pets.service.spec.ts
@@ -689,7 +689,7 @@ describe('PetsService', () => {
     expect(listed.data.find((pet) => pet.id === created.data.id)).toBeUndefined();
   });
 
-  it('deve calcular estatisticas publicas sem incluir pets bloqueados ou indisponiveis', async () => {
+  it('deve calcular estatísticas públicas sem incluir pets bloqueados ou indisponíveis', async () => {
     await service.create(
       await validateCreateDto({ ...makeCreateDto(), name: 'Dog 1', species: 'dog' }),
       mockUserIds.RAFAEL_LIMA,

--- a/central-pet-back/src/modules/pets/pets.service.spec.ts
+++ b/central-pet-back/src/modules/pets/pets.service.spec.ts
@@ -8,6 +8,7 @@ import { CreatePetDto } from './dto/create-pet.dto';
 import { UpdatePetDto } from './dto/update-pet.dto';
 import { PetsService } from './pets.service';
 import { PetSeedService } from './pet-seed.service';
+import { PetStatsEventsService } from './pet-stats-events.service';
 
 type PrismaPetRecord = {
   id: string;
@@ -51,6 +52,7 @@ describe('PetsService', () => {
   let validationPipe: ValidationPipe;
   let records: PrismaPetRecord[];
   let userRecords: Map<string, PrismaUserRecord>;
+  let petStatsEventsMock: PetStatsEventsService;
   let prismaMock: {
     pet: {
       count: jest.Mock;
@@ -388,11 +390,16 @@ describe('PetsService', () => {
       ensureSeed: jest.fn(async () => {}),
     } as unknown as PetSeedService;
 
+    petStatsEventsMock = {
+      emitChanged: jest.fn(),
+    } as unknown as PetStatsEventsService;
+
     service = new PetsService(
       prismaMock as unknown as PrismaService,
       personalityTraitsMock,
       userPersistenceMock as unknown as UserPersistenceService,
       seedServiceMock,
+      petStatsEventsMock,
     );
 
     validationPipe = new ValidationPipe({

--- a/central-pet-back/src/modules/pets/pets.service.spec.ts
+++ b/central-pet-back/src/modules/pets/pets.service.spec.ts
@@ -53,6 +53,7 @@ describe('PetsService', () => {
   let userRecords: Map<string, PrismaUserRecord>;
   let prismaMock: {
     pet: {
+      count: jest.Mock;
       create: jest.Mock;
       findMany: jest.Mock;
       findUnique: jest.Mock;
@@ -142,6 +143,22 @@ describe('PetsService', () => {
 
     prismaMock = {
       pet: {
+        count: jest.fn(
+          (args?: {
+            where?: {
+              responsibleUserId?: string;
+              deleted?: boolean;
+              status?: 'AVAILABLE' | 'ADOPTED' | 'UNAVAILABLE';
+              species?: 'DOG' | 'CAT';
+              sex?: 'MALE' | 'FEMALE';
+              size?: 'SMALL' | 'MEDIUM' | 'LARGE';
+              responsibleUser?: { state?: string };
+            };
+          }) => {
+            const matchingPets = prismaMock.pet.findMany(args) as PrismaPetRecord[];
+            return matchingPets.length;
+          },
+        ),
         create: jest.fn(
           (args: { data: Omit<PrismaPetRecord, 'id' | 'createdAt' | 'updatedAt'> }) => {
             const created: PrismaPetRecord = {
@@ -670,5 +687,49 @@ describe('PetsService', () => {
     expect(deleted.data.adoptionStatus).toBe('UNAVAILABLE');
     await expect(service.findOne(created.data.id)).rejects.toThrow(NotFoundException);
     expect(listed.data.find((pet) => pet.id === created.data.id)).toBeUndefined();
+  });
+
+  it('deve calcular estatisticas publicas sem incluir pets bloqueados ou indisponiveis', async () => {
+    await service.create(
+      await validateCreateDto({ ...makeCreateDto(), name: 'Dog 1', species: 'dog' }),
+      mockUserIds.RAFAEL_LIMA,
+    );
+    await service.create(
+      await validateCreateDto({ ...makeCreateDto(), name: 'Cat 1', species: 'cat' }),
+      mockUserIds.RAFAEL_LIMA,
+    );
+    const adopted = await service.create(
+      await validateCreateDto({ ...makeCreateDto(), name: 'Cat Adopted', species: 'cat' }),
+      mockUserIds.ANA_SOUZA,
+    );
+    const unavailable = await service.create(
+      await validateCreateDto({ ...makeCreateDto(), name: 'Dog Unavailable', species: 'dog' }),
+      mockUserIds.ANA_SOUZA,
+    );
+    const blockedAdopted = await service.create(
+      await validateCreateDto({ ...makeCreateDto(), name: 'Blocked Adopted', species: 'dog' }),
+      mockUserIds.ANA_SOUZA,
+    );
+
+    const adoptedRecord = records.find((record) => record.name === adopted.data.name)!;
+    const unavailableRecord = records.find((record) => record.name === unavailable.data.name)!;
+    const blockedAdoptedRecord = records.find(
+      (record) => record.name === blockedAdopted.data.name,
+    )!;
+
+    adoptedRecord.status = 'ADOPTED';
+    unavailableRecord.status = 'UNAVAILABLE';
+    blockedAdoptedRecord.status = 'ADOPTED';
+    blockedAdoptedRecord.deleted = true;
+
+    const result = await service.getStats();
+
+    expect(result.data).toEqual({
+      availableBySpecies: {
+        dog: 1,
+        cat: 1,
+      },
+      adopted: 1,
+    });
   });
 });

--- a/central-pet-back/src/modules/pets/pets.service.ts
+++ b/central-pet-back/src/modules/pets/pets.service.ts
@@ -18,6 +18,7 @@ import { PetSeedService } from './pet-seed.service';
 import { PetMapper } from './mappers/pet-record.mapper';
 import type { PetForAdoptionRequest, PetRecord, PetResponseRecord } from './models/pet-record';
 import { Prisma } from '@/../generated/prisma/client';
+import { PetStatsEventsService } from './pet-stats-events.service';
 export type { PetForAdoptionRequest } from './models/pet-record';
 
 const generatePetPublicIdSuffix = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 12);
@@ -44,6 +45,7 @@ export class PetsService {
     private readonly personalityTraitsService: PersonalityTraitsService,
     private readonly userPersistence: UserPersistenceService,
     private readonly petSeedService: PetSeedService,
+    private readonly petStatsEvents: PetStatsEventsService,
     @Optional() private readonly auditService?: AuditService,
   ) {}
 
@@ -311,6 +313,8 @@ export class PetsService {
       });
     }
 
+    this.petStatsEvents.emitChanged();
+
     return {
       message: 'Pet created successfully',
       data: this.withResponsibleLocation(PetMapper.toDomain(createdPet), responsibleMetadata),
@@ -472,6 +476,8 @@ export class PetsService {
       },
     });
 
+    this.petStatsEvents.emitChanged();
+
     return {
       pet: this.withResponsibleLocation(
         PetMapper.toDomain(updatedPet),
@@ -529,6 +535,8 @@ export class PetsService {
         selectedPersonalitiesJson: updatePetDto.selectedPersonalities,
       },
     });
+
+    this.petStatsEvents.emitChanged();
 
     return {
       message: 'Pet updated successfully',
@@ -678,6 +686,8 @@ export class PetsService {
     const deletedPet = await this.prisma.$transaction(async (tx) => {
       return this.removeTransactional(tx, id, performedBy);
     });
+
+    this.petStatsEvents.emitChanged();
 
     return {
       message: 'Pet deleted successfully',

--- a/central-pet-back/src/modules/pets/pets.service.ts
+++ b/central-pet-back/src/modules/pets/pets.service.ts
@@ -356,6 +356,44 @@ export class PetsService {
     };
   }
 
+  async getStats() {
+    await this.ensureMockPetsSeededIfEnabled();
+
+    const [availableDogs, availableCats, adoptedPets] = await Promise.all([
+      this.prisma.pet.count({
+        where: {
+          deleted: false,
+          status: 'AVAILABLE',
+          species: 'DOG',
+        },
+      }),
+      this.prisma.pet.count({
+        where: {
+          deleted: false,
+          status: 'AVAILABLE',
+          species: 'CAT',
+        },
+      }),
+      this.prisma.pet.count({
+        where: {
+          deleted: false,
+          status: 'ADOPTED',
+        },
+      }),
+    ]);
+
+    return {
+      message: 'Pet stats retrieved successfully',
+      data: {
+        availableBySpecies: {
+          dog: availableDogs,
+          cat: availableCats,
+        },
+        adopted: adoptedPets,
+      },
+    };
+  }
+
   async findOne(id: string) {
     await this.ensureMockPetsSeededIfEnabled();
 

--- a/central-pet-front/src/App.tsx
+++ b/central-pet-front/src/App.tsx
@@ -7,26 +7,12 @@ import Footer from '@/Layout/Footer';
 import Header from '@/Layout/Header';
 import { routes, useAppRoutes } from '@/routes';
 import { shouldDisplayMockChoiceGates } from '@/lib/dev-mode.ts';
-import { usePets } from '@/lib/pets';
+import { usePetStats } from '@/lib/pets';
 
 const App: React.FC = () => {
   const location = useLocation();
-  const filters = useMemo(
-    () => ({
-      adoptionStatus: 'AVAILABLE' as const,
-    }),
-    [],
-  );
-
-  const { pets } = usePets(filters);
-  const speciesCounts = useMemo(
-    () =>
-      pets.reduce<Record<string, number>>((counts, pet) => {
-        counts[pet.species] = (counts[pet.species] ?? 0) + 1;
-        return counts;
-      }, {}),
-    [pets],
-  );
+  const { stats } = usePetStats();
+  const speciesCounts = useMemo(() => stats.availableBySpecies, [stats.availableBySpecies]);
 
   const routedContent = useAppRoutes();
   const showSidePanel = location.pathname === routes.home.path;
@@ -43,7 +29,7 @@ const App: React.FC = () => {
 
           {showSidePanel ? (
             <aside className="hidden xl:block">
-              <SidePanel speciesCounts={speciesCounts} />
+              <SidePanel speciesCounts={speciesCounts} adoptedCount={stats.adopted} />
             </aside>
           ) : null}
         </div>

--- a/central-pet-front/src/App.tsx
+++ b/central-pet-front/src/App.tsx
@@ -11,11 +11,10 @@ import { usePetStats } from '@/lib/pets';
 
 const App: React.FC = () => {
   const location = useLocation();
-  const { stats } = usePetStats();
-  const speciesCounts = useMemo(() => stats.availableBySpecies, [stats.availableBySpecies]);
-
   const routedContent = useAppRoutes();
   const showSidePanel = location.pathname === routes.home.path;
+  const { stats } = usePetStats({ enabled: showSidePanel });
+  const speciesCounts = useMemo(() => stats.availableBySpecies, [stats.availableBySpecies]);
 
   return (
     <div className="flex min-h-screen flex-col bg-neutral-50">

--- a/central-pet-front/src/Components/SidePanel.test.tsx
+++ b/central-pet-front/src/Components/SidePanel.test.tsx
@@ -4,14 +4,15 @@ import SidePanel from '@/Components/SidePanel';
 
 describe('SidePanel', () => {
   it('renderiza labels no singular e plural conforme a contagem', () => {
-    render(<SidePanel speciesCounts={{ dog: 1, cat: 2 }} />);
+    render(<SidePanel speciesCounts={{ dog: 1, cat: 2 }} adoptedCount={4} />);
 
     expect(screen.getByText('Cachorro cadastrado')).toBeInTheDocument();
     expect(screen.getByText('Gatos cadastrados')).toBeInTheDocument();
+    expect(screen.getByText('Pets adotados pela plataforma')).toBeInTheDocument();
   });
 
   it('usa zero quando a especie nao existe no mapa de contagem', () => {
-    render(<SidePanel speciesCounts={{ dog: 3 }} />);
+    render(<SidePanel speciesCounts={{ dog: 3 }} adoptedCount={0} />);
 
     expect(
       screen.getAllByRole('heading', { level: 2 }).some((element) => element.textContent === '0'),

--- a/central-pet-front/src/Components/SidePanel.tsx
+++ b/central-pet-front/src/Components/SidePanel.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from 'react';
-import { Cat, Dog, PawPrint, type LucideIcon } from 'lucide-react';
+import { Cat, Dog, HeartHandshake, PawPrint, type LucideIcon } from 'lucide-react';
 import { petSpeciesOptions } from '@/storage/pets';
 
 interface SidePanelProps {
   speciesCounts: Record<string, number>;
+  adoptedCount: number;
 }
 
 const speciesIconByValue: Record<string, LucideIcon> = {
@@ -11,7 +12,7 @@ const speciesIconByValue: Record<string, LucideIcon> = {
   cat: Cat,
 };
 
-const SidePanel: React.FC<SidePanelProps> = ({ speciesCounts }) => {
+const SidePanel: React.FC<SidePanelProps> = ({ speciesCounts, adoptedCount }) => {
   const speciesCards = petSpeciesOptions.map((speciesOption) => ({
     ...speciesOption,
     count: speciesCounts[speciesOption.value] ?? 0,
@@ -28,6 +29,12 @@ const SidePanel: React.FC<SidePanelProps> = ({ speciesCounts }) => {
           number={speciesCard.count}
         />
       ))}
+      <StatCard
+        icon={HeartHandshake}
+        label="Pets adotados pela plataforma"
+        number={adoptedCount}
+        useFixedLabel
+      />
     </div>
   );
 };
@@ -36,11 +43,16 @@ interface StatCardProps {
   icon: LucideIcon;
   label: string;
   number: number;
+  useFixedLabel?: boolean;
 }
 
-function StatCard({ icon: Icon, label, number }: StatCardProps) {
+function StatCard({ icon: Icon, label, number, useFixedLabel = false }: StatCardProps) {
   const [count, setCount] = useState(0);
-  const normalizedLabel = number === 1 ? `${label} cadastrado` : `${label}s cadastrados`;
+  const normalizedLabel = useFixedLabel
+    ? label
+    : number === 1
+      ? `${label} cadastrado`
+      : `${label}s cadastrados`;
 
   useEffect(() => {
     let start = 0;

--- a/central-pet-front/src/Pages/MainPage.tsx
+++ b/central-pet-front/src/Pages/MainPage.tsx
@@ -1,8 +1,8 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import Carousel from '@/Components/Carousel';
 import { routes } from '@/routes';
-import { usePets } from '@/lib/pets';
+import { PET_STATS_CHANGED_BROWSER_EVENT, usePets } from '@/lib/pets';
 import { SITE_NAME } from '@/lib/site-config';
 
 const MainPage: React.FC = () => {
@@ -13,7 +13,19 @@ const MainPage: React.FC = () => {
     [],
   );
 
-  const { pets, isLoading, error } = usePets(filters);
+  const { pets, isLoading, error, refetch } = usePets(filters);
+
+  useEffect(() => {
+    const handlePetStatsChanged = () => {
+      void refetch();
+    };
+
+    window.addEventListener(PET_STATS_CHANGED_BROWSER_EVENT, handlePetStatsChanged);
+
+    return () => {
+      window.removeEventListener(PET_STATS_CHANGED_BROWSER_EVENT, handlePetStatsChanged);
+    };
+  }, [refetch]);
 
   return (
     <section className="w-full px-1 pb-8 pt-4 lg:px-0 lg:pt-5">

--- a/central-pet-front/src/lib/api.ts
+++ b/central-pet-front/src/lib/api.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const apiBaseUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api';
+export const apiBaseUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:3000/api';
 
 export const api = axios.create({
   baseURL: apiBaseUrl,

--- a/central-pet-front/src/lib/pets/index.ts
+++ b/central-pet-front/src/lib/pets/index.ts
@@ -1,2 +1,6 @@
-export { usePetStats, type PetStats } from './use-pet-stats.ts';
+export {
+  PET_STATS_CHANGED_BROWSER_EVENT,
+  usePetStats,
+  type PetStats,
+} from './use-pet-stats.ts';
 export { usePets } from './use-pets.ts';

--- a/central-pet-front/src/lib/pets/index.ts
+++ b/central-pet-front/src/lib/pets/index.ts
@@ -1,1 +1,2 @@
+export { usePetStats, type PetStats } from './use-pet-stats.ts';
 export { usePets } from './use-pets.ts';

--- a/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
@@ -20,7 +20,7 @@ describe('usePetStats', () => {
     apiGetMock.mockReset();
   });
 
-  it('carrega estatisticas dos pets', async () => {
+  it('carrega estatísticas dos pets', async () => {
     apiGetMock.mockResolvedValue({
       data: {
         data: {

--- a/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
@@ -1,13 +1,14 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { api } from '@/lib/api';
-import { usePetStats } from './use-pet-stats';
+import { PET_STATS_CHANGED_BROWSER_EVENT, usePetStats } from './use-pet-stats';
 
 const { getMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
 }));
 
 vi.mock('@/lib/api', () => ({
+  apiBaseUrl: 'http://localhost:3000/api',
   api: {
     get: getMock,
   },
@@ -15,9 +16,36 @@ vi.mock('@/lib/api', () => ({
 
 const apiGetMock = vi.mocked(api.get);
 
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  readonly options?: EventSourceInit;
+  readonly listeners = new Map<string, EventListener>();
+  readonly addEventListener = vi.fn((type: string, listener: EventListener) => {
+    this.listeners.set(type, listener);
+  });
+  readonly removeEventListener = vi.fn((type: string) => {
+    this.listeners.delete(type);
+  });
+  readonly close = vi.fn();
+
+  constructor(url: string, options?: EventSourceInit) {
+    this.url = url;
+    this.options = options;
+    MockEventSource.instances.push(this);
+  }
+
+  emit(type: string) {
+    this.listeners.get(type)?.(new MessageEvent(type));
+  }
+}
+
 describe('usePetStats', () => {
   beforeEach(() => {
+    vi.unstubAllGlobals();
     apiGetMock.mockReset();
+    MockEventSource.instances = [];
   });
 
   it('carrega estatisticas dos pets', async () => {
@@ -46,5 +74,56 @@ describe('usePetStats', () => {
     });
 
     expect(apiGetMock).toHaveBeenCalledWith('/pets/stats');
+  });
+
+  it('refaz estatisticas e notifica a home ao receber evento SSE', async () => {
+    vi.stubGlobal('EventSource', MockEventSource);
+    const localEventListener = vi.fn();
+    window.addEventListener(PET_STATS_CHANGED_BROWSER_EVENT, localEventListener);
+
+    apiGetMock
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            availableBySpecies: {
+              dog: 1,
+              cat: 0,
+            },
+            adopted: 0,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          data: {
+            availableBySpecies: {
+              dog: 2,
+              cat: 0,
+            },
+            adopted: 0,
+          },
+        },
+      });
+
+    const { result, unmount } = renderHook(() => usePetStats());
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    MockEventSource.instances[0]?.emit('pet-stats-changed');
+
+    await waitFor(() => {
+      expect(result.current.stats.availableBySpecies.dog).toBe(2);
+      expect(localEventListener).toHaveBeenCalledTimes(1);
+    });
+
+    expect(MockEventSource.instances[0]?.url).toBe('http://localhost:3000/api/pets/stats/events');
+    expect(MockEventSource.instances[0]?.options).toEqual({ withCredentials: true });
+
+    unmount();
+
+    expect(MockEventSource.instances[0]?.close).toHaveBeenCalledTimes(1);
+    window.removeEventListener(PET_STATS_CHANGED_BROWSER_EVENT, localEventListener);
   });
 });

--- a/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
@@ -1,0 +1,50 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '@/lib/api';
+import { usePetStats } from './use-pet-stats';
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: getMock,
+  },
+}));
+
+const apiGetMock = vi.mocked(api.get);
+
+describe('usePetStats', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset();
+  });
+
+  it('carrega estatisticas dos pets', async () => {
+    apiGetMock.mockResolvedValue({
+      data: {
+        data: {
+          availableBySpecies: {
+            dog: 3,
+            cat: 2,
+          },
+          adopted: 5,
+        },
+      },
+    });
+
+    const { result } = renderHook(() => usePetStats());
+
+    await waitFor(() => {
+      expect(result.current.stats).toEqual({
+        availableBySpecies: {
+          dog: 3,
+          cat: 2,
+        },
+        adopted: 5,
+      });
+    });
+
+    expect(apiGetMock).toHaveBeenCalledWith('/pets/stats');
+  });
+});

--- a/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pet-stats.test.tsx
@@ -76,7 +76,7 @@ describe('usePetStats', () => {
     expect(apiGetMock).toHaveBeenCalledWith('/pets/stats');
   });
 
-  it('refaz estatisticas e notifica a home ao receber evento SSE', async () => {
+  it('refaz estatísticas e notifica a home ao receber evento SSE', async () => {
     vi.stubGlobal('EventSource', MockEventSource);
     const localEventListener = vi.fn();
     window.addEventListener(PET_STATS_CHANGED_BROWSER_EVENT, localEventListener);

--- a/central-pet-front/src/lib/pets/use-pet-stats.ts
+++ b/central-pet-front/src/lib/pets/use-pet-stats.ts
@@ -1,0 +1,51 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '@/lib/api';
+
+export type PetStats = {
+  availableBySpecies: Record<string, number>;
+  adopted: number;
+};
+
+interface UsePetStatsResult {
+  stats: PetStats;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+const emptyPetStats: PetStats = {
+  availableBySpecies: {},
+  adopted: 0,
+};
+
+export const usePetStats = (): UsePetStatsResult => {
+  const [stats, setStats] = useState<PetStats>(emptyPetStats);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetchStats = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await api.get<{ data: PetStats }>('/pets/stats');
+      setStats(response.data.data);
+    } catch (err) {
+      setStats(emptyPetStats);
+      setError(err instanceof Error ? err : new Error('Erro ao carregar estatísticas dos pets'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchStats();
+  }, [fetchStats]);
+
+  return {
+    stats,
+    isLoading,
+    error,
+    refetch: fetchStats,
+  };
+};

--- a/central-pet-front/src/lib/pets/use-pet-stats.ts
+++ b/central-pet-front/src/lib/pets/use-pet-stats.ts
@@ -1,9 +1,16 @@
 import { useCallback, useEffect, useState } from 'react';
-import { api } from '@/lib/api';
+import { api, apiBaseUrl } from '@/lib/api';
+
+export const PET_STATS_CHANGED_BROWSER_EVENT = 'central-pet:pet-stats-changed';
+const PET_STATS_CHANGED_SERVER_EVENT = 'pet-stats-changed';
 
 export type PetStats = {
   availableBySpecies: Record<string, number>;
   adopted: number;
+};
+
+type UsePetStatsOptions = {
+  enabled?: boolean;
 };
 
 interface UsePetStatsResult {
@@ -18,10 +25,15 @@ const emptyPetStats: PetStats = {
   adopted: 0,
 };
 
-export const usePetStats = (): UsePetStatsResult => {
+const isDocumentVisible = () =>
+  typeof document === 'undefined' || document.visibilityState === 'visible';
+
+export const usePetStats = (options: UsePetStatsOptions = {}): UsePetStatsResult => {
+  const { enabled = true } = options;
   const [stats, setStats] = useState<PetStats>(emptyPetStats);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
+  const [isVisible, setIsVisible] = useState(isDocumentVisible);
 
   const fetchStats = useCallback(async () => {
     setIsLoading(true);
@@ -39,8 +51,48 @@ export const usePetStats = (): UsePetStatsResult => {
   }, []);
 
   useEffect(() => {
+    if (!enabled || !isVisible) return;
+
     void fetchStats();
-  }, [fetchStats]);
+  }, [enabled, fetchStats, isVisible]);
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      setIsVisible(isDocumentVisible());
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !isVisible || typeof EventSource === 'undefined') return;
+
+    const source = new EventSource(`${apiBaseUrl}/pets/stats/events`, {
+      withCredentials: true,
+    });
+    let isRefetching = false;
+
+    const handleStatsChanged = () => {
+      if (isRefetching) return;
+
+      isRefetching = true;
+      void fetchStats().finally(() => {
+        isRefetching = false;
+        window.dispatchEvent(new Event(PET_STATS_CHANGED_BROWSER_EVENT));
+      });
+    };
+
+    source.addEventListener(PET_STATS_CHANGED_SERVER_EVENT, handleStatsChanged);
+
+    return () => {
+      source.removeEventListener(PET_STATS_CHANGED_SERVER_EVENT, handleStatsChanged);
+      source.close();
+    };
+  }, [enabled, fetchStats, isVisible]);
 
   return {
     stats,

--- a/central-pet-front/src/lib/pets/use-pets.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pets.test.tsx
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { api } from '@/lib/api';
-import { usePets } from './use-pets';
+import { usePets } from '@/lib/pets/use-pets';
 
 const { getMock } = vi.hoisted(() => ({
   getMock: vi.fn(),

--- a/central-pet-front/src/lib/pets/use-pets.test.tsx
+++ b/central-pet-front/src/lib/pets/use-pets.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '@/lib/api';
+import { usePets } from './use-pets';
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    get: getMock,
+  },
+}));
+
+const apiGetMock = vi.mocked(api.get);
+
+describe('usePets', () => {
+  beforeEach(() => {
+    apiGetMock.mockReset();
+    window.localStorage.clear();
+  });
+
+  it('envia os filtros informados para a API de pets', async () => {
+    apiGetMock.mockImplementation((url: string) => {
+      if (url === '/pets') {
+        return Promise.resolve({
+          data: {
+            data: [],
+          },
+        });
+      }
+
+      return Promise.resolve({
+        data: {
+          data: [],
+        },
+      });
+    });
+
+    renderHook(() =>
+      usePets({
+        adoptionStatus: 'AVAILABLE',
+        species: 'CAT',
+        state: 'SP',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(apiGetMock).toHaveBeenCalledWith('/pets', {
+        params: {
+          adoptionStatus: 'AVAILABLE',
+          species: 'CAT',
+          state: 'SP',
+        },
+      });
+    });
+  });
+});

--- a/tests/e2e/adoption-workflow.spec.ts
+++ b/tests/e2e/adoption-workflow.spec.ts
@@ -45,9 +45,9 @@ test.describe.serial("Fluxo de Adoção", () => {
     // 1. ADOTANTE: Solicitar adoção
     await fazerLogin(page, adopter);
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
     // Selecionar o pet exato pelo nome único usando exact text
     const petCard = page.locator("h3").filter({ hasText: pet.name }).first();
+    await expect(petCard).toBeVisible({ timeout: 15000 });
     await petCard.click({ force: true });
 
     await page.getByRole("link", { name: "Quero adotar" }).click();
@@ -64,8 +64,6 @@ test.describe.serial("Fluxo de Adoção", () => {
     await fazerLogout(page);
     await fazerLogin(page, donor);
     await page.goto("/adoption-requests");
-    await page.waitForLoadState("networkidle");
-
     const receivedCard = page
       .locator("article")
       .filter({ hasText: pet.name })
@@ -98,9 +96,8 @@ test.describe.serial("Fluxo de Adoção", () => {
   }) => {
     await fazerLogin(page, donor);
     await page.goto("/");
-    await page.waitForLoadState("networkidle");
-
     const petCard = page.locator("h3").filter({ hasText: pet.name }).first();
+    await expect(petCard).toBeVisible({ timeout: 15000 });
     await petCard.click({ force: true });
     await page.getByRole("link", { name: "Quero adotar" }).click();
 

--- a/tests/e2e/pet-update-workflow.spec.ts
+++ b/tests/e2e/pet-update-workflow.spec.ts
@@ -11,7 +11,7 @@ import { obterImagemFixtureParaUpload } from "../utils/file-fixtures";
  * Teste E2E: fluxo de atualização de pets.
  * Dividido em mini-testes para cobrir cada seção do formulário.
  */
-test.describe("Fluxo de Atualização de Pets - Seções", () => {
+test.describe.serial("Fluxo de Atualização de Pets - Seções", () => {
   let petId: string;
   let usuario: any;
   let petIdsCriados: string[] = [];


### PR DESCRIPTION
# 🐾 Pull Request — Central-Pet

  ## 📌 Descrição

  Este PR corrige os contadores exibidos na página inicial e adiciona um novo card de estatística para pets adotados
  pela plataforma.

  - Os cards de cães e gatos agora usam estatísticas reais do backend.
  - A contagem de cães e gatos considera apenas pets disponíveis para adoção (`AVAILABLE`) e não removidos/bloqueados
  (`deleted = false`).
  - Foi adicionado o card “Pets adotados pela plataforma”, contando pets com status `ADOPTED`, independentemente da
  espécie.
  - Foi criado o endpoint público `GET /pets/stats` para centralizar a regra de contagem no backend e evitar buscar
  listas completas apenas para calcular totais.
  - O hook `usePets` foi ajustado para enviar filtros corretamente como query params.
  - O Prisma Client foi regenerado para refletir os campos atuais do schema de pets (`publicId`, `deletedAt`,
  `deletedBy`, `deletedReason`), corrigindo falha nos testes E2E de adoção.

  ---

  ## 🎯 Tipo de Alteração

  - [x] 🆕 Nova funcionalidade
  - [x] 🐛 Correção de bug
  - [ ] ♻️ Refatoração de código
  - [ ] 📝 Documentação
  - [x] 🎨 Melhoria de interface
  - [ ] ⚡ Melhoria de performance
  - [ ] 🔐 Segurança
  - [x] ✅ Testes

  ---

  ## 🛠️ Como Testar

  1. Regenerar o Prisma Client, se necessário:
     `corepack pnpm --filter central-pet-back prisma:generate`

  2. Executar validações do backend:
     `pnpm test:back`

  3. Executar validações do frontend:
     `pnpm --filter central-pet-front typecheck`
     `pnpm --filter central-pet-front test:run`

  Resultado esperado:

  - A página inicial exibe cards com cães e gatos disponíveis.
  - O novo card “Pets adotados pela plataforma” exibe o total de pets adotados.
  - Pets bloqueados/removidos não entram nas contagens.
  - O fluxo E2E de adoção não falha mais com `Unknown argument publicId`.

  ---

  ## 📦 Novas Dependências

  Dependência:
  Nenhuma nova dependência foi adicionada.

  Nome da biblioteca:
  N/A

  Motivo da adição:
  N/A

  Alternativas consideradas:
  N/A

  ---

  ## 📷 Prints ou Vídeos (se aplicável)

  Não aplicável.

  ---

  ## 📋 Checklist

  - [x] Meu código segue o padrão definido pelo projeto
  - [x] Testei localmente e está funcionando corretamente
  - [x] Não gerei novos erros ou warnings
  - [x] Atualizei a documentação (se necessário)
  - [ ] O nome da branch segue o padrão (feature/, fix/, refactor/, etc.)

  ---

  ## 🔗 Issue Relacionada

  Closes #87 

  ---

  ## 💬 Observações Adicionais

  Durante a validação, o erro do E2E de adoção foi identificado como Prisma Client desatualizado em relação ao schema
  atual. Após regenerar o client, o fluxo de adoção voltou a criar pets com `publicId` corretamente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Novo endpoint de estatísticas e stream SSE para atualizações em tempo real; hook de estatísticas com opção de ativação e evento global.
  * Painel lateral agora mostra contador de pets adotados; página principal refaz lista ao receber atualizações.

* **Tests**
  * Testes adicionados/atualizados para o hook de estatísticas, stream SSE, contadores e hooks de pets.

* **Bug Fixes**
  * Ajustes em testes e sincronizações E2E para maior estabilidade.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CentralPetPJI/Central-Pet/pull/89)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->